### PR TITLE
AWS EC2Autoscaler -- Accept Tags

### DIFF
--- a/docs/content/configuration/indexing-service.md
+++ b/docs/content/configuration/indexing-service.md
@@ -134,6 +134,7 @@ A sample worker config spec is shown below:
     "minNumWorkers": 2,
     "maxNumWorkers": 12,
     "envConfig": {
+      "region": "us-east-1",
       "availabilityZone": "us-east-1a",
       "nodeData": {
         "amiId": "${AMI}",
@@ -141,7 +142,12 @@ A sample worker config spec is shown below:
         "minInstances": 1,
         "maxInstances": 1,
         "securityGroupIds": ["${IDs}"],
-        "keyName": ${KEY_NAME}
+        "keyName": "${KEY_NAME}",
+        "subnetId": "${SUBNET_ID}",
+        "iamProfile": {
+          "name": "${IAM_PROFILE_NAME}",
+          "arn": "${IAM_PROFILE_INSTANCE_PROFILE_ARN}"
+        }
       },
       "userData": {
         "impl": "string",

--- a/docs/content/configuration/indexing-service.md
+++ b/docs/content/configuration/indexing-service.md
@@ -147,7 +147,11 @@ A sample worker config spec is shown below:
         "iamProfile": {
           "name": "${IAM_PROFILE_NAME}",
           "arn": "${IAM_PROFILE_INSTANCE_PROFILE_ARN}"
-        }
+        },
+        "tags": [
+          { "key1": "value1" },
+          { "key2": "value2" }
+        ]
       },
       "userData": {
         "impl": "string",

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/autoscaling/ec2/EC2AutoScaler.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/autoscaling/ec2/EC2AutoScaler.java
@@ -19,6 +19,7 @@
 
 package io.druid.indexing.overlord.autoscaling.ec2;
 
+import com.amazonaws.regions.RegionUtils;
 import com.amazonaws.services.ec2.AmazonEC2;
 import com.amazonaws.services.ec2.model.DescribeInstancesRequest;
 import com.amazonaws.services.ec2.model.DescribeInstancesResult;
@@ -70,6 +71,15 @@ public class EC2AutoScaler implements AutoScaler<EC2EnvironmentConfig>
     this.envConfig = envConfig;
     this.amazonEC2Client = amazonEC2Client;
     this.config = config;
+
+    final String regionName = envConfig.getRegion();
+    if (regionName != null) {
+      try {
+        amazonEC2Client.setRegion(RegionUtils.getRegion(regionName));
+      } catch (IllegalArgumentException e) {
+        log.warn(e, String.format("Invalid region: %s", regionName));
+      }
+    }
   }
 
   @Override

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/autoscaling/ec2/EC2EnvironmentConfig.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/autoscaling/ec2/EC2EnvironmentConfig.java
@@ -27,19 +27,27 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class EC2EnvironmentConfig
 {
   private final String availabilityZone;
+  private final String region;
   private final EC2NodeData nodeData;
   private final EC2UserData userData;
 
   @JsonCreator
   public EC2EnvironmentConfig(
+      @JsonProperty("region") String region,
       @JsonProperty("availabilityZone") String availabilityZone,
       @JsonProperty("nodeData") EC2NodeData nodeData,
       @JsonProperty("userData") EC2UserData userData
   )
   {
+    this.region = region;
     this.availabilityZone = availabilityZone;
     this.nodeData = nodeData;
     this.userData = userData;
+  }
+
+  @JsonProperty
+  public String getRegion() {
+    return region;
   }
 
   @JsonProperty
@@ -64,6 +72,7 @@ public class EC2EnvironmentConfig
   public String toString()
   {
     return "EC2EnvironmentConfig{" +
+           "region='" + region + '\'' +
            "availabilityZone='" + availabilityZone + '\'' +
            ", nodeData=" + nodeData +
            ", userData=" + userData +
@@ -82,6 +91,9 @@ public class EC2EnvironmentConfig
 
     EC2EnvironmentConfig that = (EC2EnvironmentConfig) o;
 
+    if (region != null ? !region.equals(that.region) : that.region != null) {
+      return false;
+    }
     if (availabilityZone != null ? !availabilityZone.equals(that.availabilityZone) : that.availabilityZone != null) {
       return false;
     }
@@ -98,7 +110,8 @@ public class EC2EnvironmentConfig
   @Override
   public int hashCode()
   {
-    int result = availabilityZone != null ? availabilityZone.hashCode() : 0;
+    int result = region != null ? region.hashCode() : 0;
+    result = 31 * result + (availabilityZone != null ? availabilityZone.hashCode() : 0);
     result = 31 * result + (nodeData != null ? nodeData.hashCode() : 0);
     result = 31 * result + (userData != null ? userData.hashCode() : 0);
     return result;

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/autoscaling/ec2/EC2NodeData.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/autoscaling/ec2/EC2NodeData.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  */
@@ -37,6 +38,7 @@ public class EC2NodeData
   private final String subnetId;
   private final EC2IamProfileData iamProfile;
   private final Boolean associatePublicIpAddress;
+  private final List<Map<String, String>> tags;
 
   @JsonCreator
   public EC2NodeData(
@@ -48,7 +50,8 @@ public class EC2NodeData
       @JsonProperty("keyName") String keyName,
       @JsonProperty("subnetId") String subnetId,
       @JsonProperty("iamProfile") EC2IamProfileData iamProfile,
-      @JsonProperty("associatePublicIpAddress") Boolean associatePublicIpAddress
+      @JsonProperty("associatePublicIpAddress") Boolean associatePublicIpAddress,
+      @JsonProperty("tags") List<Map<String, String>> tags
   )
   {
     this.amiId = amiId;
@@ -60,6 +63,7 @@ public class EC2NodeData
     this.subnetId = subnetId;
     this.iamProfile = iamProfile;
     this.associatePublicIpAddress = associatePublicIpAddress;
+    this.tags = tags;
   }
 
   @JsonProperty
@@ -116,6 +120,12 @@ public class EC2NodeData
     return associatePublicIpAddress;
   }
 
+  @JsonProperty
+  public List<Map<String, String>> getTags()
+  {
+    return tags;
+  }
+
   @Override
   public String toString()
   {
@@ -127,7 +137,8 @@ public class EC2NodeData
            ", securityGroupIds=" + securityGroupIds +
            ", keyName='" + keyName + '\'' +
            ", subnetId='" + subnetId + '\'' +
-           ", iamProfile=" + iamProfile +
+           ", iamProfile='" + iamProfile + '\'' +
+           ", tags=" + tags +
            '}';
   }
 
@@ -167,6 +178,9 @@ public class EC2NodeData
     if (subnetId != null ? !subnetId.equals(that.subnetId) : that.subnetId != null) {
       return false;
     }
+    if (tags != null ? !tags.equals(that.tags) : that.tags != null) {
+      return false;
+    }
 
     return true;
   }
@@ -182,6 +196,7 @@ public class EC2NodeData
     result = 31 * result + (keyName != null ? keyName.hashCode() : 0);
     result = 31 * result + (subnetId != null ? subnetId.hashCode() : 0);
     result = 31 * result + (iamProfile != null ? iamProfile.hashCode() : 0);
+    result = 31 * result + (tags != null ? tags.hashCode() : 0);
     return result;
   }
 }

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/autoscaling/EC2AutoScalerSerdeTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/autoscaling/EC2AutoScalerSerdeTest.java
@@ -33,6 +33,9 @@ import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class EC2AutoScalerSerdeTest
 {
   private AmazonEC2Client amazonEC2Client = EasyMock.createMock(AmazonEC2Client.class);
@@ -63,7 +66,11 @@ public class EC2AutoScalerSerdeTest
                       + "         \"minInstances\" : 1,\n"
                       + "         \"securityGroupIds\" : [\"kingsguard\"],\n"
                       + "         \"subnetId\" : \"redkeep\",\n"
-                      + "         \"iamProfile\" : {\"name\": \"foo\", \"arn\": \"bar\"}\n"
+                      + "         \"iamProfile\" : {\"name\": \"foo\", \"arn\": \"bar\"},\n"
+                      + "         \"tags\" : [\n"
+                      + "           {\"name\": \"joffrey\"},\n"
+                      + "           {\"role\": \"production\"}\n"
+                      + "         ]\n"
                       + "      },\n"
                       + "      \"userData\" : {\n"
                       + "         \"data\" : \"VERSION=:VERSION:\\n\","
@@ -88,7 +95,8 @@ public class EC2AutoScalerSerdeTest
                       + "         \"minInstances\" : 1,\n"
                       + "         \"securityGroupIds\" : [\"kingsguard\"],\n"
                       + "         \"subnetId\" : \"redkeep\",\n"
-                      + "         \"iamProfile\" : {\"name\": \"foo\", \"arn\": \"bar\"}\n"
+                      + "         \"iamProfile\" : {\"name\": \"foo\", \"arn\": \"bar\"},\n"
+                      + "         \"tags\" : null\n"
                       + "      },\n"
                       + "      \"userData\" : {\n"
                       + "         \"data\" : \"VERSION=:VERSION:\\n\","
@@ -118,6 +126,18 @@ public class EC2AutoScalerSerdeTest
     );
     verifyAutoScaler(roundTripAutoScaler);
     Assert.assertEquals("westeros-east-1", autoScaler.getEnvConfig().getRegion());
+    Assert.assertEquals(2, autoScaler.getEnvConfig().getNodeData().getTags().size());
+
+    Map<String, String> expectedNameMap = new HashMap<>();
+    expectedNameMap.put("name", "joffrey");
+    Map<String, String> expectedRoleMap = new HashMap<>();
+    expectedRoleMap.put("role", "production");
+    Assert.assertEquals(
+        true,
+        expectedNameMap.equals(autoScaler.getEnvConfig().getNodeData().getTags().get(0)));
+    Assert.assertEquals(
+        true,
+        expectedRoleMap.equals(autoScaler.getEnvConfig().getNodeData().getTags().get(1)));
 
     Assert.assertEquals("Round trip equals", autoScaler, roundTripAutoScaler);
   }
@@ -139,6 +159,7 @@ public class EC2AutoScalerSerdeTest
     );
     verifyAutoScaler(roundTripAutoScaler);
     Assert.assertEquals(null, autoScaler.getEnvConfig().getRegion());
+    Assert.assertEquals(null, autoScaler.getEnvConfig().getNodeData().getTags());
 
     Assert.assertEquals("Round trip equals", autoScaler, roundTripAutoScaler);
   }

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/autoscaling/EC2AutoScalerTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/autoscaling/EC2AutoScalerTest.java
@@ -22,6 +22,7 @@ package io.druid.indexing.overlord.autoscaling;
 import com.amazonaws.regions.Region;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.ec2.AmazonEC2Client;
+import com.amazonaws.services.ec2.model.CreateTagsRequest;
 import com.amazonaws.services.ec2.model.DescribeInstancesRequest;
 import com.amazonaws.services.ec2.model.DescribeInstancesResult;
 import com.amazonaws.services.ec2.model.Filter;
@@ -29,6 +30,7 @@ import com.amazonaws.services.ec2.model.Instance;
 import com.amazonaws.services.ec2.model.Reservation;
 import com.amazonaws.services.ec2.model.RunInstancesRequest;
 import com.amazonaws.services.ec2.model.RunInstancesResult;
+import com.amazonaws.services.ec2.model.Tag;
 import com.amazonaws.services.ec2.model.TerminateInstancesRequest;
 import com.google.common.base.Functions;
 import com.google.common.collect.ContiguousSet;
@@ -49,7 +51,9 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  */
@@ -57,16 +61,43 @@ public class EC2AutoScalerTest
 {
   private static final String AMI_ID = "dummy";
   private static final String INSTANCE_ID = "theInstance";
+  private static final Map<String, String> tagMap;
+  static
+  {
+    tagMap = new HashMap<>();
+    tagMap.put("role", "production");
+  }
+  private static final List<Map<String, String>> TAGS = Collections.singletonList(tagMap);
   public static final EC2EnvironmentConfig ENV_CONFIG = new EC2EnvironmentConfig(
       "us-east-1",
       "us-east-1a",
-      new EC2NodeData(AMI_ID, INSTANCE_ID, 1, 1, Lists.<String>newArrayList(), "foo", "mySubnet", null, null),
+      new EC2NodeData(
+          AMI_ID,
+          INSTANCE_ID,
+          1,
+          1,
+          Lists.<String>newArrayList(),
+          "foo",
+          "mySubnet",
+          null,
+          null,
+          TAGS),
       new GalaxyEC2UserData(new DefaultObjectMapper(), "env", "version", "type")
   );
   public static final EC2EnvironmentConfig LEGACY_ENV_CONFIG = new EC2EnvironmentConfig(
       null,
       "us-east-1a",
-      new EC2NodeData(AMI_ID, INSTANCE_ID, 1, 1, Lists.<String>newArrayList(), "foo", "mySubnet", null, null),
+      new EC2NodeData(
+          AMI_ID,
+          INSTANCE_ID,
+          1,
+          1,
+          Lists.<String>newArrayList(),
+          "foo",
+          "mySubnet",
+          null,
+          null,
+          null),
       new GalaxyEC2UserData(new DefaultObjectMapper(), "env", "version", "type")
   );
   private static final String IP = "dummyIP";
@@ -134,9 +165,28 @@ public class EC2AutoScalerTest
   }
 
   @Test
+  public void testDoesNotSetTagsIfNull()
+  {
+    new EC2AutoScaler(
+        0,
+        1,
+        LEGACY_ENV_CONFIG,
+        amazonEC2Client,
+        managementConfig
+    );
+    EasyMock.replay(amazonEC2Client);
+    EasyMock.replay(describeInstancesResult);
+    EasyMock.replay(reservation);
+  }
+
+  @Test
   public void testScale()
   {
     RunInstancesResult runInstancesResult = EasyMock.createMock(RunInstancesResult.class);
+    CreateTagsRequest createTagsRequest = new CreateTagsRequest(
+        Collections.singletonList("theInstance"),
+        Collections.singletonList(new Tag("role", "production"))
+    );
 
     EC2AutoScaler autoScaler = new EC2AutoScaler(
         0,
@@ -150,6 +200,8 @@ public class EC2AutoScalerTest
     EasyMock.expect(amazonEC2Client.runInstances(EasyMock.anyObject(RunInstancesRequest.class))).andReturn(
         runInstancesResult
     );
+    amazonEC2Client.createTags(createTagsRequest);
+    EasyMock.expectLastCall().once();
     EasyMock.expect(amazonEC2Client.describeInstances(EasyMock.anyObject(DescribeInstancesRequest.class)))
             .andReturn(describeInstancesResult);
     EasyMock.expect(amazonEC2Client.terminateInstances(EasyMock.anyObject(TerminateInstancesRequest.class)))

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/autoscaling/ec2/EC2NodeDataTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/autoscaling/ec2/EC2NodeDataTest.java
@@ -20,11 +20,15 @@
 package io.druid.indexing.overlord.autoscaling.ec2;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.client.util.Lists;
 import io.druid.jackson.DefaultObjectMapper;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class EC2NodeDataTest
 {
@@ -32,9 +36,18 @@ public class EC2NodeDataTest
   public void testSerde() throws Exception
   {
     final ObjectMapper objectMapper = new DefaultObjectMapper();
-    final String json = "{ \"amiId\" : \"abc123\", \"instanceType\" : \"k2.9xsmall\", \"minInstances\" : 1, \"maxInstances\" : 2,"
-                        + " \"securityGroupIds\" : [\"sg-abc321\"], \"keyName\" : \"opensesame\", \"subnetId\" : \"darknet2\","
-                        + " \"associatePublicIpAddress\" : true, \"iamProfile\" : { \"name\" : \"john\", \"arn\" : \"xxx:abc:1234/xyz\" } }";
+    final String json = "{"
+                        + "\"amiId\" : \"abc123\","
+                        + "\"instanceType\" : \"k2.9xsmall\","
+                        + "\"minInstances\" : 1,"
+                        + "\"maxInstances\" : 2,"
+                        + " \"securityGroupIds\" : [\"sg-abc321\"],"
+                        + "\"keyName\" : \"opensesame\","
+                        + "\"subnetId\" : \"darknet2\","
+                        + " \"associatePublicIpAddress\" : true,"
+                        + "\"iamProfile\" : { \"name\" : \"john\", \"arn\" : \"xxx:abc:1234/xyz\" },"
+                        + "\"tags\" : [{ \"env\" : \"production\"}, {\"name\" : \"tagName\" }]"
+                        + "}";
     EC2NodeData nodeData = objectMapper.readValue(json, EC2NodeData.class);
 
     Assert.assertEquals("abc123", nodeData.getAmiId());
@@ -47,6 +60,16 @@ public class EC2NodeDataTest
     Assert.assertEquals("john", nodeData.getIamProfile().getName());
     Assert.assertEquals("xxx:abc:1234/xyz", nodeData.getIamProfile().getArn());
     Assert.assertEquals(true, nodeData.getAssociatePublicIpAddress());
+
+    Map<String, String> expectedTagMap1 = new HashMap<>();
+    Map<String, String> expectedTagMap2 = new HashMap<>();
+    expectedTagMap1.put("env", "production");
+    expectedTagMap2.put("name", "tagName");
+    List<Map<String, String>> expectedTags = Lists.newArrayList();
+    expectedTags.add(expectedTagMap1);
+    expectedTags.add(expectedTagMap2);
+
+    Assert.assertEquals(true, expectedTags.equals(nodeData.getTags()));
 
     EC2NodeData nodeData2 = objectMapper.readValue("{}", EC2NodeData.class);
     // default is not always false, null has to be a valid value

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/setup/WorkerBehaviorConfigTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/setup/WorkerBehaviorConfigTest.java
@@ -36,12 +36,23 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class WorkerBehaviorConfigTest
 {
 
   private AmazonEC2Client amazonEC2Client;
   private InjectableValues mockInjectableValues;
+  private static final Map<String, String> tagMap;
+  static
+  {
+    tagMap = new HashMap<>();
+    tagMap.put("role", "production");
+  }
+  private static final List<Map<String, String>> TAGS = Collections.singletonList(tagMap);
 
   @Before
   public void setUp() throws Exception
@@ -87,7 +98,8 @@ public class WorkerBehaviorConfigTest
                     "keyNames",
                     "subnetId",
                     null,
-                    null
+                    null,
+                    TAGS
                 ),
                 new StringEC2UserData(
                     "availZone",
@@ -109,7 +121,7 @@ public class WorkerBehaviorConfigTest
   }
 
   @Test
-  public void testSerdeNullRegion() throws Exception
+  public void testSerdeLegacyConfig() throws Exception
   {
     WorkerBehaviorConfig config = new WorkerBehaviorConfig(
         new FillCapacityWithAffinityWorkerSelectStrategy(
@@ -131,6 +143,7 @@ public class WorkerBehaviorConfigTest
                     Arrays.asList("securityGroupIds"),
                     "keyNames",
                     "subnetId",
+                    null,
                     null,
                     null
                 ),


### PR DESCRIPTION
- Update dynamic worker config to contain "tags" key, which will
  tag newly provisioned instances on autoscaling events.
- Add tests for legacy configs (with null tags)
